### PR TITLE
Fixing calls to deprecated roslib.rosenv (fixes #2)

### DIFF
--- a/rosh/shell.py
+++ b/rosh/shell.py
@@ -17,8 +17,8 @@ for p in plugins:
     load(p, globals())
 
 # load the user's roshrc file, if present
-import roslib.rosenv as _rosenv
-_roshrcp = os.path.join(_rosenv.get_ros_home(), 'rosh', 'roshrc.py')
+import rospkg
+_roshrcp = os.path.join(rospkg.get_ros_home(), 'rosh', 'roshrc.py')
 if os.path.isfile(_roshrcp):
     print "loading roshrc"
     try:
@@ -42,4 +42,4 @@ del plugins
 del sys
 del os
 del _roshrcp
-del _rosenv
+del rospkg

--- a/rosh/src/rosh/__init__.py
+++ b/rosh/src/rosh/__init__.py
@@ -45,7 +45,6 @@ import os
 import sys
 
 import roslib.packages
-import roslib.rosenv
 
 # declare shell globals
 

--- a/rosh/src/rosh/impl/ipy.py
+++ b/rosh/src/rosh/impl/ipy.py
@@ -40,7 +40,7 @@ import sys
 
 import roslib.packages
 import roslib.stacks
-import roslib.rosenv
+import rospkg
 
 def pkg_stack_completers(self, event):
     return roslib.packages.list_pkgs() + roslib.stacks.list_stacks()
@@ -64,7 +64,7 @@ def ipy_magic_init():
 
 def ipy_roscd(magic, target):
     if not target:
-        magic.magic_cd(roslib.rosenv.get_ros_root())
+        magic.magic_cd(rospkg.get_ros_root())
     else:
         splits = target.split(os.sep)
         target = splits[0]

--- a/rosh/src/rosh/impl/proc.py
+++ b/rosh/src/rosh/impl/proc.py
@@ -42,7 +42,7 @@ manipulate the environment in ways that would affect subprocesses.
 import os
 from subprocess import Popen, PIPE
 
-import roslib.rosenv
+import rosgraph.rosenv
 import roslaunch
 
 # TODO: get rid of this routine or replace with Exec
@@ -51,7 +51,7 @@ def run(config, cmd, stdout=True):
     Run the specified command using the current ROS configuration.
     """
     env = os.environ.copy()
-    env[roslib.rosenv.ROS_MASTER_URI] = config.master.master_uri
+    env[rosgraph.rosenv.ROS_MASTER_URI] = config.master.master_uri
     
     if 0:
         print "CMD", cmd

--- a/rosh/src/rosh/impl/topic.py
+++ b/rosh/src/rosh/impl/topic.py
@@ -52,6 +52,7 @@ from roslib.packages import get_pkg_dir
 import rosmsg
 import rostopic
 import rospy
+import rospkg
 
 import rosh.impl.proc
 from rosh.impl.exceptions import ROSHException
@@ -624,7 +625,7 @@ def show_graph(ns_obj):
     
 def show_rostopic(ns_obj):
     # rostopic echo in a separate window
-    ros_root = roslib.rosenv.get_ros_root()
+    ros_root = rospkg.get_ros_root()
     success = rosh.impl.proc.run(ns_obj._config, ['xterm', '-e', os.path.join(ros_root, 'bin', 'rostopic'), 'echo', ns_obj._name], stdout=False)
     # TODO: return proc object instead
     if success:


### PR DESCRIPTION
Note: didn't fix in roshlaunch or future.py since they aren't used.
