### PR TITLE
Launch named node, pass args through

### DIFF
--- a/rosh/src/rosh/impl/packages.py
+++ b/rosh/src/rosh/impl/packages.py
@@ -168,9 +168,11 @@ class LaunchableNode(object):
         self.type = os.path.basename(path_)
         self.path = os.path.dirname(path_)
         self.roslaunch_node = roslaunch_node
-    def __call__(self, *args, **kwds):
+    def __call__(self, node_name=None, *args, **kwds):
         # launch returns list of Nodes that were launched, so unwrap
-        return self.ctx.launch(self.as_Node(), args=args, remap=kwds)[0]
+        node = self.as_Node()
+        node.name = node_name
+        return self.ctx.launch(node, args=args, remap=kwds)[0]
         
     def as_Node(self):
         if self.roslaunch_node:

--- a/rosh/src/rosh/impl/packages.py
+++ b/rosh/src/rosh/impl/packages.py
@@ -172,7 +172,9 @@ class LaunchableNode(object):
         # launch returns list of Nodes that were launched, so unwrap
         node = self.as_Node()
         node.name = node_name
-        return self.ctx.launch(node, args=args, remap=kwds)[0]
+        node.remap_args = kwds.items()
+        self.roslaunch_node = node
+        return self.ctx.launch(node, args=args)[0]
         
     def as_Node(self):
         if self.roslaunch_node:


### PR DESCRIPTION
Two changes:
- Make it possible to explicitly name nodes
- Pass kwds to the Node object so it will launch with remappings
